### PR TITLE
R3.9/test fail update

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: rWikiPathways
 Type: Package
 Title: rWikiPathways - R client library for the WikiPathways API
-Version: 1.4.0
-Date: 2019-04-22
+Version: 1.4.1
+Date: 2019-07-20
 Authors@R: c(person("Egon", "Willighagen", role = c("aut","cre"),
                      email = "egon.willighagen@gmail.com",
                      comment = c(ORCID = "0000-0001-7542-0286")),

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,7 @@
+Changes in version 1.4.1
++ Bug fixes
+    - Updated the findPathwaysByLiterature test case (fixing a false positive fail)
+
 Changes in version 1.4.0
 + Bug fixes
     - Fixed createSubnetwork -- #43 network suids i/o names

--- a/tests/testthat/test-findPathwaysByLiterature.R
+++ b/tests/testthat/test-findPathwaysByLiterature.R
@@ -7,7 +7,7 @@ test_that("find by keyword", {
 })
 
 test_that("find by pmid (again)", {
-    pathways = findPathwaysByLiterature(query="19649250")
+    pathways = findPathwaysByLiterature(query="10423528")
     expect_gt(length(pathways), 0)
 })
 


### PR DESCRIPTION
@AlexanderPico, I got a small patch to "fix" the regression on BioC. The replaced pmid is of one of the WikiPathways papers, which must have been cited by one of the pathways. I could not figure out which pathway, nor why lookup with that pmid does not work anymore.

So, I replaced it with a pmid of another paper, which does give a hit. Basically, the package and the API is working, and it was just an independent data issue.

But, I do not seem to have push rights for this package, so like to ask if you can pull in these two patches (one with the fix, the other with the version dump; that way, the fix patch can easily 'git cherry-pick'ed into master, where the version update patch is not wanted/needed).

BTW, I did not seem able to make the patch against your repo's RELEASE_3_9, because it's a tag, and only against master, but that is not where it should go. So, the recipe is basically:

0. `git fetch --all`
1. `git checkout -b RELEASE_3_9`
2. then `git cherry-pick` the two patches from this pull request

Alternatively, do the first two, and then push that RELEASE_3_9 branch to your repo, and I make a proper pull request.